### PR TITLE
Add Slope property and Plot function to Equation struct

### DIFF
--- a/piecewiseLinearApprox.go
+++ b/piecewiseLinearApprox.go
@@ -5,6 +5,12 @@ import (
 	"strconv"
 )
 
+func getPlotFunction(slope float64, beginX float64, beginY float64) func(float64) float64 {
+	return func(x float64) float64 {
+		return slope * (x - beginX) + beginY
+	}
+}
+
 func PiecewiseLinearApprox(timeSeries []Pair, tollerance float64) []Equation {
 	var expression string
 	var interval Pair
@@ -28,13 +34,14 @@ func PiecewiseLinearApprox(timeSeries []Pair, tollerance float64) []Equation {
 			lower = lowerPrime
 			upper = upperPrime
 		} else {
+			slope := (upper+lower)/2
 			expression = "y = " +
-				strconv.FormatFloat((upper+lower)/2, 'g', -1, 64) + "(t - " +
+				strconv.FormatFloat(slope, 'g', -1, 64) + "(t - " +
 				strconv.FormatFloat(begin.X, 'g', -1, 64) +
 				") + " + strconv.FormatFloat(begin.Y, 'g', -1, 64)
 
 			interval = Pair{start, end}
-			equations = append(equations, Equation{expression, interval})
+			equations = append(equations, Equation{expression, interval, slope, getPlotFunction(slope, begin.X, begin.Y)})
 
 			begin = Pair{timeSeries[i].X, ValueAtTime(lower, upper,
 				timeSeries[i].X, begin)}
@@ -47,13 +54,14 @@ func PiecewiseLinearApprox(timeSeries []Pair, tollerance float64) []Equation {
 	}
 	end = timeSeries[len(timeSeries)-1].X
 
+	slope := (upper+lower)/2
 	expression = "y = " +
-		strconv.FormatFloat((upper+lower)/2, 'g', -1, 64) + "(t - " +
+		strconv.FormatFloat(slope, 'g', -1, 64) + "(t - " +
 		strconv.FormatFloat(begin.X, 'g', -1, 64) +
 		") + " + strconv.FormatFloat(begin.Y, 'g', -1, 64)
 
 	interval = Pair{start, end}
-	equations = append(equations, Equation{expression, interval})
+	equations = append(equations, Equation{expression, interval, slope, getPlotFunction(slope, begin.X, begin.Y)})
 
 	return equations
 }

--- a/piecewiseLinearApprox_test.go
+++ b/piecewiseLinearApprox_test.go
@@ -165,6 +165,23 @@ func TestPiecewiseLinearApprox(t *testing.T) {
 		}
 	}
 
+	// test the first equation
+	equation1 := solution[0]
+	if equation1.Slope != 2 {
+		t.Errorf("Slope returned %g expecting 2", equation1.Slope)
+	}
+
+	// try plotting a point
+	value := equation1.Plot(0)
+	if value != 0 {
+		t.Errorf("Plot returned %g expecting 0", value)
+	}
+
+	value = equation1.Plot(5)
+	if value != 10 {
+		t.Errorf("Plot returned %g expecting 10", value)
+	}
+
 	solution2 := piecewiseLinearApproximation.PiecewiseLinearApprox(timeSeries2, tollerance2)
 	for i := 0; i < len(equations2); i++ {
 		expression2 := solution2[i].Expression

--- a/types.go
+++ b/types.go
@@ -11,4 +11,6 @@ type Pair struct {
 type Equation struct {
 	Expression string
 	Interval   Pair
+    Slope float64
+    Plot func(float64) float64
 }

--- a/types.go
+++ b/types.go
@@ -11,6 +11,6 @@ type Pair struct {
 type Equation struct {
 	Expression string
 	Interval   Pair
-    Slope float64
-    Plot func(float64) float64
+	Slope float64
+	Plot func(float64) float64
 }


### PR DESCRIPTION
I am aware this library may not be maintained, but I was using it and wanted some additional functionality so I figured I would at least submit a pull request.

I implemented two changes:

- Added a `Slope` property to the `Equation` struct which lets you get the slope of an equation as a float using `equation.Slope`
- Added a `Plot` function to the `Equation` struct which lets you plot any point on the new linear approximation.

    This is so that you can pass in a bunch of points and then generate equations, and from the equations get back a new set of points that fit to the linear equations. You pass in the `x` coordinate is a float and get back the y coordinate.

Arguably it might be better to get back an array of all of the new points on the linear graph instead of the individual equations, but these changes made what I wanted to do easier.

Thanks for the library!